### PR TITLE
fix OS X v0.5pre keylayout link

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,7 +552,7 @@
     </dt>
     <dt>
       <strong> Mac OSX : </strong> (v0.5pre)
-      <a href="./v0.5pre/lafayette_macosx_20151217.keylayout">lafayette_macosx_20151217.keylayout</a> (58 Ko)
+      <a href="./v0.5pre/lafayette_macosx_20151216.keylayout">lafayette_macosx_20151216.keylayout</a> (58 Ko)
     </dt>
     <dd>
       <p>


### PR DESCRIPTION
altough OS X won't show me the input method in keyboard setting using this file