### PR TITLE
Reading Unicode as UTF-8

### DIFF
--- a/releases/lafayette_linux_v0.6.1.py
+++ b/releases/lafayette_linux_v0.6.1.py
@@ -269,7 +269,7 @@ for locale, layouts in LAYOUTS.items():
     text = ''
     between_marks = False
     modified_text = False
-    with open(path, 'r+') as symbols:
+    with open(path, 'r+', encoding='utf-8') as symbols:
         # load system symbols without any previous 'lafayette' layouts
         for line in symbols:
             if line.endswith(MARK_BEGIN):


### PR DESCRIPTION
According to [Reading and Writing Unicode Data](https://docs.python.org/3/howto/unicode.html#reading-and-writing-unicode-data), the standard function open of [lafayette_linux_v0.6.1.py#L272](https://github.com/fabi1cazenave/qwerty-lafayette/blob/b17e0767ca4a62a3f09931778f0c8712ef5ddd17/releases/lafayette_linux_v0.6.1.py#L272) is  argumentable as utf-8 encoding.
That solve misadventure like [UnicodeDecodeError: 'ascii' codec can't decode byte](https://stackoverflow.com/questions/23917729/switching-to-python-3-causing-unicodedecodeerror)