### PR TITLE
Update qwerty-fr description

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ Alternatives
 There are other ways to use a Qwerty-US keyboard for French. Here are the two most intuitive ones:
 
 * [qwerty-intl](https://en.wikipedia.org/wiki/QWERTY#US-International) — turns <kbd>`</kbd><kbd>~</kbd><kbd>'</kbd><kbd>"</kbd><kbd>^</kbd> into dead keys;
-* [qwerty-fr](https://github.com/julienblitte/qwerty-fr) — smart use of the AltGr layer for direct access to all French accented characters, as well as dead keys for other characters.
+* [qwerty-fr](https://github.com/qwerty-fr/qwerty-fr) — smart use of the AltGr layer for direct access to all French accented characters, as well as dead keys for other characters.
 
 Qwerty-Lafayette provides sharper typography and better ergonomics in the long run, but has a steeper learning curve for non-touch-typists.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ Alternatives
 There are other ways to use a Qwerty-US keyboard for French. Here are the two most intuitive ones:
 
 * [qwerty-intl](https://en.wikipedia.org/wiki/QWERTY#US-International) — turns <kbd>`</kbd><kbd>~</kbd><kbd>'</kbd><kbd>"</kbd><kbd>^</kbd> into dead keys;
-* [qwerty-fr](http://marin.jb.free.fr/qwerty-fr/) — no dead keys, and a smart use of the AltGr layer for all French accented characters.
+* [qwerty-fr](https://github.com/julienblitte/qwerty-fr) — smart use of the AltGr layer for direct access to all French accented characters, as well as dead keys for other characters.
 
 Qwerty-Lafayette provides sharper typography and better ergonomics in the long run, but has a steeper learning curve for non-touch-typists.


### PR DESCRIPTION
- It *does* have dead keys (for example AltGr + Shift + ` + o gives õ).
- It's now on GitHub.